### PR TITLE
Explicit call out to the swapping that takes place

### DIFF
--- a/src/common/inc/net.h
+++ b/src/common/inc/net.h
@@ -100,7 +100,7 @@ int netEnumInterfaces(netIfCallback callback, netContext* ctx, void* userData);
 // Creates a virtual Ethernet pair of interfaces with endpoints in the given
 // namespaces. If the MAC addresses are not NULL, they are used to configure the
 // new interfaces.
-int netCreateVethPair(const char* name1, const char* name2, netContext* ctx1, netContext* ctx2, const macAddr* addr1, const macAddr* addr2, int mtu, bool sync);
+int netCreateVethPair(const char* intfName1, const char* intfName2, netContext* ctx1, netContext* ctx2, const macAddr* addr1, const macAddr* addr2, int mtu, bool sync);
 
 // Returns the interface index for an interface. On error, returns -1 and sets
 // err (if provided) to the error code.

--- a/src/common/lib/net.c
+++ b/src/common/lib/net.c
@@ -577,10 +577,10 @@ cleanup:
 	return err;
 }
 
-int netCreateVethPair(const char* name1, const char* name2, netContext* ctx1, netContext* ctx2, const macAddr* addr1, const macAddr* addr2, int mtu, bool sync) {
+int netCreateVethPair(const char* intfName1, const char* intfName2, netContext* ctx1, netContext* ctx2, const macAddr* addr1, const macAddr* addr2, int mtu, bool sync) {
 	if (PASSES_LOG_THRESHOLD(LogDebug)) {
 		lprintHead(LogDebug);
-		lprintDirectf(LogDebug, "Creating virtual ethernet pair (%p:'%s', %p:'%s')", ctx1, name1, ctx2, name2);
+		lprintDirectf(LogDebug, "Creating virtual ethernet pair (%p:'%s', %p:'%s')", ctx1, intfName1, ctx2, intfName2);
 		char mac[MAC_ADDR_BUFLEN];
 		if (addr1 != NULL) {
 			macAddrToString(addr1, mac);
@@ -606,7 +606,7 @@ int netCreateVethPair(const char* name1, const char* name2, netContext* ctx1, ne
 
 	nlPushAttr(nl, IFLA_IFNAME);
 	{
-		nlBufferAppend(nl, name1, strlen(name1) + 1);
+		nlBufferAppend(nl, intfName1, strlen(intfName1) + 1);
 	}
 	nlPopAttr(nl);
 
@@ -649,7 +649,7 @@ int netCreateVethPair(const char* name1, const char* name2, netContext* ctx1, ne
 				nlBufferAppend(nl, &ifi, sizeof(ifi));
 				nlPushAttr(nl, IFLA_IFNAME);
 				{
-					nlBufferAppend(nl, name2, strlen(name2) + 1);
+					nlBufferAppend(nl, intfName2, strlen(intfName2) + 1);
 				}
 				nlPopAttr(nl);
 				nlPushAttr(nl, IFLA_NET_NS_FD);

--- a/src/netmirage-core/worker.c
+++ b/src/netmirage-core/worker.c
@@ -447,6 +447,7 @@ static int workGetLinkEndpoints(nodeId id1, nodeId id2, char* name1, char* name2
 	*net2 = ncOpenNamespace(nc, id2, name2, false, false, &err);
 	if (*net2 == NULL) return err;
 
+	// Notice: intf1 is created from id2, and vice versa
 	sprintf(intf1, "%s-%u", NodeLinkPrefix, id2);
 	sprintf(intf2, "%s-%u", NodeLinkPrefix, id1);
 


### PR DESCRIPTION
Gotcha within the workGetLinkEndpoints function around using id1 to create interface name 2, and vice versa - called it out with a comment. 

Also, updated the parameter names in netCreateVethPair to better reflect that it there are interface names being passed to the function. Within workerAddLink, there are strings called "sourceName" and "targetName" which are not actually passed through to buildVethPair or netCreateVethPair. Changing the parameters to indicate that netCreateVethPair accepts interface names, and not these other name strings, can make the code easier to understand.